### PR TITLE
Now the content in all nodes in env-list is malloced and freed by environment

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -76,12 +76,20 @@ void add_special_character_element(t_main *main, char *input, int *i, int split_
 /*****************************************************************************/
 
 /**
- * Frees all nodes in the environment linked list (but not the content, because
- * the content is malloced by split?)
+ * Frees all nodes an their content in the environment linked list
  * 
  * @param env_list pointer to the linked list to free
  */
 void    free_environment(t_list **env_list);
+
+/**
+ * Finds and returns a node with the same key as variable
+ * 
+ * @param main the main struct of the program
+ * @param variable a key-value pair in form KEY=value to find node for
+ * @returns pointer to a node with the same key as variable
+ */
+t_list	*find_node(t_main *main, char *variable);
 
 /**
  * Adds a variable to the environment (a new node to the linked list)
@@ -92,7 +100,7 @@ void    free_environment(t_list **env_list);
 void    add_variable(t_main *main, char *content);
 
 /**
- * Copies the values from envp into a linked list
+ * Duplicates (mallocs) the values from envp into a linked list
  * 
  * @param envp the environment pointer gotten from main
  * @param main the main struct of the program
@@ -112,7 +120,7 @@ void	print_linked_list(t_list *env_list);
 void	print_list_content(void *content);
 
 /**
- * Removes one node from the linked list
+ * Frees and removes the node that has key varaible_key from the linked list
  * 
  * @param main the main struct of the program
  * @param variable_key the key of the variable to remove

--- a/sources/environment/environment_utils.c
+++ b/sources/environment/environment_utils.c
@@ -21,16 +21,33 @@ void    free_environment(t_list **env_list)
     while (current_node != NULL)
 	{
 		temp = current_node->next;
+		free(current_node->content);
 		free(current_node);
 		current_node = temp;
 	}
+}
+
+t_list	*find_node(t_main *main, char *variable)
+{
+	int		key_len;
+	t_list	*current_node;
+
+	key_len = ft_strchr(variable, '=') - variable;
+	current_node = main->env_list;
+	while (current_node != NULL)
+	{
+		if (ft_strncmp(variable, current_node->content, key_len) == 0)
+			return (current_node);
+		current_node = current_node->next;
+	}
+	return (NULL);
 }
 
 void    add_variable(t_main *main, char *content)
 {
     t_list  *new_node;
 
-    new_node = ft_lstnew(content);
+    new_node = ft_lstnew(ft_strdup(content));
     if (new_node == NULL)
     {
         perror("Error");
@@ -55,6 +72,7 @@ void	remove_variable(t_main *main, char *variable_key)
 		current_node = previous_node->next;
 	}
 	next_node = current_node->next;
+	free(current_node->content);
 	free(current_node);
 	previous_node->next = next_node;
 }
@@ -65,19 +83,19 @@ t_list	*copy_env(char *envp[], t_main *main)
 	t_list	*new;
 	int		i;
 
-	i = 0;
+	new = ft_lstnew(ft_strdup(envp[0]));
+	if (new == NULL)
+	{
+		perror("Error");
+        ft_free_split(&(main->split_input));
+	}
+	env_list = new;
+	main->env_list = env_list;
+	i = 1;
 	while (envp[i] != NULL)
 	{
-		new = ft_lstnew(envp[i]);
-		if (i == 0)
-		{
-			env_list = new;
-			i++;
-			continue;
-		}
-		ft_lstadd_back(&env_list, new);
+		add_variable(main, envp[i]);
 		i++;
 	}
-	main->env_list = env_list;
 	return (env_list);
 }


### PR DESCRIPTION
Because otherwise the exported variables would be freed after each commandline when the command has been executed. Also added function to find a node.